### PR TITLE
Remove sunshine streaming + fix removed hyprland vfr option

### DIFF
--- a/nix/home/hyprland/hyprland.nix
+++ b/nix/home/hyprland/hyprland.nix
@@ -197,10 +197,6 @@
       animations = {
         enabled = false;
       };
-
-      misc = {
-        vfr = false;
-      };
     };
   };
 }

--- a/nix/system/remote-access.nix
+++ b/nix/system/remote-access.nix
@@ -3,30 +3,5 @@ _:
 {
   services.tailscale.enable = true;
 
-  services.sunshine = {
-    enable = true;
-    autoStart = true;
-    capSysAdmin = true;
-    openFirewall = true;
-  };
-
-  networking.firewall = {
-    enable = true;
-    allowedTCPPorts = [
-      47984
-      47989
-      47990
-      48010
-    ];
-    allowedUDPPortRanges = [
-      {
-        from = 47998;
-        to = 48000;
-      }
-      {
-        from = 8000;
-        to = 8010;
-      }
-    ];
-  };
+  networking.firewall.enable = true;
 }


### PR DESCRIPTION
## Summary
- **hyprland**: drop the `misc:vfr` option, removed in Hyprland 0.55 (VFR is now automatic). It was throwing a config error on every load.
- **remote-access**: remove the `services.sunshine` block and its Sunshine-only firewall ports. Tailscale and the firewall stay enabled.

No `apollo` or `moonlight` references existed in the config.

## Verification
- `hyprctl configerrors` returns empty after reload
- `nix eval .#nixosConfigurations.ghstation...toplevel` evaluates cleanly